### PR TITLE
feat(buckets): add CRYOSTAT_BUCKETS for pre-created buckets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install -y go git make gettext \
     && popd
 
 FROM registry.access.redhat.com/ubi8/ubi-micro:${runner_version}
-COPY --from=builder /usr/bin/envsubst /root/go/bin/weed /root/seaweedfs/docker/entrypoint.sh /usr/bin/
+COPY --from=builder /usr/bin/envsubst /root/go/bin/weed /usr/bin/
 COPY ./cryostat-entrypoint.bash /usr/bin/
 COPY seaweed_conf.template.json /etc/seaweed_conf.template.json
 ENTRYPOINT ["/usr/bin/cryostat-entrypoint.bash"]

--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -49,6 +49,6 @@ createBuckets "${names[@]}" &
 
 exec weed -logtostderr=true server \
     -dir="${DATA_DIR:-/tmp}" \
-    -master.volumePreallocate -volume.max="${VOLUME_MAX:-0}" -master.volumeSizeLimitMB=4096 \
+    -master.volumePreallocate="${VOLUME_PREALLOCATE:-true}" -volume.max="${VOLUME_MAX:-0}" -master.volumeSizeLimitMB="${VOLUME_SIZE_LIMIT_MB:-4096}" \
     -s3 -s3.config="${cfg}" \
     "$@"

--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -15,6 +15,26 @@ set -xe
 cfg="$(mktemp)"
 envsubst '$CRYOSTAT_ACCESS_KEY $CRYOSTAT_SECRET_KEY' < /etc/seaweed_conf.template.json > "${cfg}"
 
+function createBuckets() {
+    for i in $(echo "$CRYOSTAT_BUCKETS" | tr ',' '\n'); do
+        local len
+        len="${#i}"
+        if [ "${len}" -lt 3 ]; then
+            echo "Bucket names must be at least 3 characters"
+            exit 1
+        fi
+        if [ "${len}" -gt 63 ]; then
+            echo "Bucket names must be at most 63 characters"
+            exit 1
+        fi
+        local cmd
+        # FIXME do something better than sleeping here
+        cmd="sleep ${BUCKET_CREATION_STARTUP_SECONDS:-30} ; echo \"s3.bucket.create -name ${i}\" | weed shell"
+        bash -c "${cmd}" &
+    done
+}
+createBuckets
+
 exec /usr/bin/entrypoint.sh \
     server -dir="${DATA_DIR:-/tmp}" \
     -s3 -s3.config="${cfg}" \

--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -26,7 +26,7 @@ function createBucket() {
 
 function createBuckets() {
     waitForStartup
-    for name in "${names[@]}"; do
+    for name in "$@"; do
         createBucket "${name}"
     done
 }

--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -17,6 +17,7 @@ envsubst '$CRYOSTAT_ACCESS_KEY $CRYOSTAT_SECRET_KEY' < /etc/seaweed_conf.templat
 
 function waitForStartup() {
     echo "cluster.check" | timeout "${BUCKET_CREATION_STARTUP_SECONDS:-30}"s weed shell 1>/dev/null 2>/dev/null || true
+    sleep "${BUCKET_CREATION_DELAY_SECONDS:-5}"
 }
 
 function createBucket() {

--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -47,7 +47,8 @@ done
 
 createBuckets "${names[@]}" &
 
-exec /usr/bin/entrypoint.sh \
-    server -dir="${DATA_DIR:-/tmp}" \
+exec weed -logtostderr=true server \
+    -dir="${DATA_DIR:-/tmp}" \
+    -master.volumePreallocate -volume.max="${VOLUME_MAX:-0}" -master.volumeSizeLimitMB=4096 \
     -s3 -s3.config="${cfg}" \
     "$@"

--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -17,7 +17,6 @@ envsubst '$CRYOSTAT_ACCESS_KEY $CRYOSTAT_SECRET_KEY' < /etc/seaweed_conf.templat
 
 function waitForStartup() {
     echo "cluster.check" | timeout "${BUCKET_CREATION_STARTUP_SECONDS:-30}"s weed shell 1>/dev/null 2>/dev/null || true
-    sleep "${BUCKET_CREATION_DELAY_SECONDS:-5}"
 }
 
 function createBucket() {


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #3
Based on #1
Depends on #1

## Description of the change:
Adds an environment variable `CRYOSTAT_BUCKETS` that defines a comma-separated list of bucket names that should be automatically created in the storage volume.

## Motivation for the change:
See #1. It is useful to be able to declare the required buckets on the storage container itself, so that applications (like cryostat) that expect particular buckets to exist can simply assume that they do/will, rather than needing to implement behaviour to check and create them all the time on their own.

An alternate approach is to figure out what initialization work actually needs to be done (ie what is `weed shell` doing under the covers), and see if it is possible to do that work before executing the original entrypoint script and bootstrapping the system. This is probably more fragile to any underlying implementation changes by Seaweed, however.

## How to manually test:
1. `./build.bash`
2. Run the just-built image, ex.: `podman run --rm -it -e CRYOSTAT_ACCESS_KEY=a -e CRYOSTAT_SECRET_KEY=b -e CRYOSTAT_BUCKETS=archivedrecordings -e WEED_V=4 -p 8333:8333 -p 8888:8888 cryostat-storage:latest`
3. Wait some time (up to 30 seconds), then use the `aws` CLI and run: `AWS_ACCESS_KEY_ID=a AWS_SECRET_ACCESS_KEY=b aws s3 ls --endpoint-url http://localhost:8333`
4. The result should be a line like `2024-01-16 18:01:26 archivedrecordings`, indicating the creation time of the one bucket specified in the `CRYOSTAT_BUCKETS` env var. Repeat this test with different `CRYOSTAT_BUCKETS` values, separated by commas, with lengths from 3 to 63 characters.