### PR TITLE
ci(build): build latest release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Get date tag
       run: echo "DATE_TAG=$(date -uI)" >> "$GITHUB_ENV"
     - name: Get SeaweedFS release ref
-      run: echo "SEAWEED_REF=$(gh release list --repo=seaweedfs/seaweedfs | head -n1 | column -1 | cut -d ' ' -f 1)"
+      run: echo "SEAWEED_REF=$(gh release list --repo=seaweedfs/seaweedfs | head -n1 | column -t | cut -d ' ' -f 1)"
     - name: Build container images and manifest
       id: buildah-build
       uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         sudo apt-get install -y qemu-user-static
     - name: Get date tag
       run: echo "DATE_TAG=$(date -uI)" >> "$GITHUB_ENV"
+    - name: Get SeaweedFS release ref
+      run: echo "SEAWEED_REF=$(gh release list --repo=seaweedfs/seaweedfs | head -n1 | column -1 | cut -d ' ' -f 1)"
     - name: Build container images and manifest
       id: buildah-build
       uses: redhat-actions/buildah-build@v2
@@ -41,6 +43,8 @@ jobs:
         image: ${{ env.CI_IMG }}
         archs: amd64, arm64
         tags: ${{ github.ref_name }} ${{ github.ref == 'refs/heads/main' && 'latest' || '' }} ${{ env.DATE_TAG }}
+        build-args: |
+          ref=${{ env.SEAWEED_REF }}
         containerfiles: |
           ./Dockerfile
     - name: Push to quay.io


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #5

## Description of the change:
CI determines the latest release version of the SeaweedFS base and builds that, rather than building from `master`.

## Motivation for the change:
`master` is the active development branch and is not necessarily stable. We don't need to track that bleeding edge of development - packaging the latest release version makes more sense.
