### PR TITLE
build(container): add label for SeaweedFS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 ARG builder_version=8.9
 ARG runner_version=8.9
+ARG ref=master
 
 FROM registry.access.redhat.com/ubi8/ubi:${builder_version} AS builder
-ARG ref=master
+ARG ref
 RUN dnf install -y go git make gettext \
     && pushd /root \
     && git clone --depth 1 --branch $ref https://github.com/seaweedfs/seaweedfs \
@@ -12,6 +13,8 @@ RUN dnf install -y go git make gettext \
     && popd
 
 FROM registry.access.redhat.com/ubi8/ubi-micro:${runner_version}
+ARG ref
+LABEL seaweedfs.version=$ref
 COPY --from=builder /usr/bin/envsubst /root/go/bin/weed /usr/bin/
 COPY ./cryostat-entrypoint.bash /usr/bin/
 COPY seaweed_conf.template.json /etc/seaweed_conf.template.json

--- a/build.bash
+++ b/build.bash
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+set -xe
+
 DIR="$(dirname "$(readlink -f "$0")")"
 
 BUILDER="${BUILDER:-podman}"
 
-${BUILDER} build "${DIR}" -f "${DIR}/Dockerfile" -t quay.io/cryostat/cryostat-storage:latest
+${BUILDER} build "${DIR}" -f "${DIR}/Dockerfile" --build-arg ref="${SEAWEED_REF:-master}" -t quay.io/cryostat/cryostat-storage:latest


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #9

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
