### PR TITLE
chore(volume): only set volume server tuning parameters if env vars provided, do not preallocate volumes by default

### DIFF
--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -47,8 +47,19 @@ done
 
 createBuckets "${names[@]}" &
 
+FLAGS=()
+
+if [ -n "${VOLUME_MAX}" ]; then
+    FLAGS+=("-volume.max=${VOLUME_MAX}")
+fi
+
+if [ -n "${VOLUME_SIZE_LIMIT_MB}" ]; then
+    FLAGS+=("-master.volumeSizeLimitMB=${VOLUME_SIZE_LIMIT_MB}")
+fi
+
 exec weed -logtostderr=true server \
     -dir="${DATA_DIR:-/tmp}" \
-    -master.volumePreallocate="${VOLUME_PREALLOCATE:-true}" -volume.max="${VOLUME_MAX:-0}" -master.volumeSizeLimitMB="${VOLUME_SIZE_LIMIT_MB:-4096}" \
+    -master.volumePreallocate="${VOLUME_PREALLOCATE:-false}" \
+    "${FLAGS[@]}" \
     -s3 -s3.config="${cfg}" \
     "$@"


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #<issue number>

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
