### PR TITLE
fix(volumes): increase volume count and decrease size to ensure available volumes for s3 buckets

### DIFF
--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -47,15 +47,13 @@ done
 
 createBuckets "${names[@]}" &
 
-FLAGS=()
+VOLUME_MIN=40
 
-if [ -n "${VOLUME_MAX}" ]; then
-    FLAGS+=("-volume.max=${VOLUME_MAX}")
-fi
-
-if [ -n "${VOLUME_SIZE_LIMIT_MB}" ]; then
-    FLAGS+=("-master.volumeSizeLimitMB=${VOLUME_SIZE_LIMIT_MB}")
-fi
+FLAGS=(
+    "-volume.max=$(( VOLUME_MAX > VOLUME_MIN ? VOLUME_MAX : VOLUME_MIN ))"
+    "-volume.fileSizeLimitMB=${FILE_SIZE_LIMIT_MB:-4096}"
+    "-master.volumeSizeLimitMB=${VOLUME_SIZE_LIMIT_MB:-256}"
+)
 
 exec weed -logtostderr=true server \
     -dir="${DATA_DIR:-/tmp}" \

--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -49,12 +49,14 @@ createBuckets "${names[@]}" &
 
 VOLUME_MIN=40
 NUM_VOLUMES=$(( VOLUME_MAX > VOLUME_MIN ? VOLUME_MAX : VOLUME_MIN ))
-STORAGE_CAPACITY=${STORAGE_CAPACITY:-10GB}
+DATA_DIR="${DATA_DIR:-/tmp}"
+AVAILABLE_DISK_BYTES="$(df -P -B1 "${DATA_DIR}" | tail -1 | tr -s ' ' | cut -d' ' -f 4)"
+STORAGE_CAPACITY=${STORAGE_CAPACITY:-${AVAILABLE_DISK_BYTES}}
 STORAGE_CAPACITY_BYTES=$(echo "${STORAGE_CAPACITY}" | numfmt --from=iec --suffix=B | tr -d 'B')
 VOLUME_SIZE_BYTES=$(( "${STORAGE_CAPACITY_BYTES}" / "${NUM_VOLUMES}" ))
 
 exec weed -logtostderr=true server \
-    -dir="${DATA_DIR:-/tmp}" \
+    -dir="${DATA_DIR}" \
     -volume.max=${NUM_VOLUMES} \
     -volume.fileSizeLimitMB="${FILE_SIZE_LIMIT_MB:-4096}" \
     -master.volumeSizeLimitMB="$(( "${VOLUME_SIZE_BYTES}" / 1024 / 1024 ))" \


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat3/issues/370
Related to https://github.com/cryostatio/cryostat-storage/pull/14

## Description of the change:
After some more review of SeaweedFS docs, it is expected that each S3 bucket will have multiple volumes allocated to it, even when those volumes are not yet filled. Once the volumes are filled then each bucket will also claim more of the free volumes. In practice with the Cryostat 3 smoketest I find that 28 volumes are needed for the `archivedreports,archivedrecordings,eventtemplates` set of buckets after some light exercising to upload a custom template, create some active recordings, create multiple copies of archived recordings, and generate reports for each of those recordings. The number of claimed volumes reaches 28 as soon as each bucket has a single file of content, and it seems to stay at 28 (presumably until the volumes become full). Therefore, 40 seems like a reasonable number of volumes to allocate. The maximum size of each volume is defaulted to a relatively small 256MB here (Seaweed's default is 30**GB**), but this number should be tuned to suit the disk space actually allocated to storage. Seaweed's default strategy is to divide the available disk space by the volume size and assign that many volumes, but this strategy does not work well when using the S3 interface which actually imposes a minimum number of volumes. Instead, we should assign a minimum number of volumes, then divide the desired total storage capacity by the number of volumes, and assign this result as the maximum volume size. Therefore, the tuning knobs to do so are exposed by environment variable, so that the Operator (and Helm chart?) can do this math based on the PVC supplied to the storage container.

The default selections of 40 volumes and 256MB per volume implies a total maximum storage capacity of 10GB. The container should happily run with less disk space available than that - it will just complain about not having disk space if it does fill up sooner. However, if the desired storage capacity is larger than 10GB (ie. a PVC larger than that is being assigned), then this is when it becomes important to tune the maximum volume size and increase it past 256MB. Otherwise, assigning a 50GB volume will not help, and the container will still only store and manage up to 10GB of content, leaving the rest of the disk unused and unavailable.

**Question**: should the "disk space / 40" calculation just be done in this entrypoint script instead of putting that work onto the Helm chart/Operator? Should we always assume that whatever disk space we see available to this container, should always be fully allocated to it? (this also has implications for https://github.com/cryostatio/cryostat-operator/pull/727 , where a single PVC is assigned and shared between both the cryostat-storage container and a postgresql database).