### PR TITLE
fix(startup): set startup sleep default value

### DIFF
--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -35,7 +35,6 @@ function createBuckets() {
     for name in "$@"; do
         createBucket "${name}"
     done
-    echo "Ready."
 }
 
 names=()

--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -22,7 +22,7 @@ function waitForStartup() {
         sleep "${BUCKET_CREATION_STARTUP_SECONDS:-10}"
     done
     echo "Cluster ready for bucket creation."
-    sleep "${BUCKET_CREATION_DELAY_SECONDS:-$BUCKET_CREATION_STARTUP_SECONDS}"
+    sleep "${BUCKET_CREATION_DELAY_SECONDS:-${BUCKET_CREATION_STARTUP_SECONDS:-3}}"
 }
 
 function createBucket() {
@@ -35,6 +35,7 @@ function createBuckets() {
     for name in "$@"; do
         createBucket "${name}"
     done
+    echo "Ready."
 }
 
 names=()


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #30

Noticed while reviewing the log output in #30 that the startup time between storage readiness and bucket creation attempts was improperly written and no default value was set, so this is corrected.
