### PR TITLE
fix(leader-election): disable resumeState

### DIFF
--- a/cryostat-entrypoint.bash
+++ b/cryostat-entrypoint.bash
@@ -56,6 +56,7 @@ createBuckets "${names[@]}" &
 set -e
 
 exec weed -logtostderr=true mini \
+    -master.resumeState=false \
     -admin.ui=false \
     -filer.allowedOrigins="${FILER_ORIGINS:-0.0.0.0}" \
     -filer.encryptVolumeData \


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #138

## Description of the change:
*This change allows an environment variable to be configured so that...*

## Motivation for the change:
*This change is helpful because users may want to...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
