### PR TITLE
ci: refactor, add podman service_timeout config

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,12 @@ jobs:
           ref=master
         containerfiles: |
           ./Dockerfile
+    - name: Save container image
+      run: podman save -o cryostat-storage.tar --format oci-archive ${{ env.CI_IMG }}:nightly-ci
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: cryostat-storage
+        path: cryostat-storage.tar
 
   test:
     if: ${{ github.repository_owner == 'cryostatio' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,49 +29,12 @@ jobs:
           ref=master
         containerfiles: |
           ./Dockerfile
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: ${{ github.repository_owner }}/cryostat
-        ref: main
-        submodules: true
-        fetch-depth: 0
-    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: 'maven'
-    - run: git submodule init && git submodule update
-    - name: Cache yarn packages
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: "./src/main/webui/.yarn/cache"
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-    - name: Initialize web assets
-      run: |
-        cd src/main/webui
-        yarn install && yarn yarn:frzinstall
-        cd -
-    - name: Install podman-docker
-      run: |
-        sudo apt -y update && sudo apt -y install "podman-docker"
-    - name: Start Podman API
-      run: systemctl --user enable --now podman.socket
-    - name: Set DOCKER_HOST environment variable
-      run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
-    - name: Build cryostat
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-      env:
-        CRYOSTAT_STORAGE_VERSION: nightly-ci
-      with:
-        attempt_limit: 3
-        command: |
-          ./mvnw -B \
-            -Dquarkus.hibernate-orm.log.sql=false \
-            -Dquarkus.log.level=error \
-            -Dquarkus.http.access-log.enabled=false \
-            -Dquarkus.smallrye-graphql.log-payload=off \
-            clean verify
+
+  test:
+    if: ${{ github.repository_owner == 'cryostatio' }}
+    needs: build
+    uses: ./.github/workflows/test-cryostat.yml
+    with:
+      java-version: '21'
+      storage-image-tag: nightly-ci
+      run-full-verify: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,5 +35,5 @@ jobs:
     needs: build
     uses: ./.github/workflows/test-cryostat.yml
     with:
-      java-version: '21'
+      java-version: '25'
       storage-image-tag: nightly-ci

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,4 +37,3 @@ jobs:
     with:
       java-version: '21'
       storage-image-tag: nightly-ci
-      run-full-verify: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,5 +35,4 @@ jobs:
     needs: build
     uses: ./.github/workflows/test-cryostat.yml
     with:
-      java-version: '25'
       storage-image-tag: nightly-ci

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,4 +35,4 @@ jobs:
     needs: build
     uses: ./.github/workflows/test-cryostat.yml
     with:
-      storage-image-tag: nightly-ci
+      storage-image: quay.io/cryostat/cryostat-storage:nightly-ci

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -33,81 +33,12 @@ jobs:
         tags: pr-ci
         containerfiles: |
           ./Dockerfile
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: ${{ github.repository_owner }}/cryostat
-        ref: main
-        submodules: true
-        fetch-depth: 0
-    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
-      with:
-        java-version: '25'
-        distribution: 'temurin'
-        cache: 'maven'
-    - run: git submodule init && git submodule update
-    - name: Cache yarn packages
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: "./src/main/webui/.yarn/cache"
-        key: ${{ runner.os }}-build-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-yarn-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-    - name: Initialize web assets
-      run: |
-        cd src/main/webui
-        yarn install && yarn yarn:frzinstall
-        cd -
-    - name: Install podman-docker
-      run: |
-        sudo apt -y update && sudo apt -y install "podman-docker"
-    - name: Start Podman API
-      run: systemctl --user enable --now podman.socket
-    - name: Set DOCKER_HOST environment variable
-      run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
-    - name: Run unit tests
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-      env:
-        CRYOSTAT_STORAGE_VERSION: pr-ci
-      with:
-        attempt_limit: 3
-        command: |
-          ./mvnw -B -U \
-            -Dquarkus.hibernate-orm.log.sql=false \
-            -Dquarkus.log.level=error \
-            -Dquarkus.http.access-log.enabled=false \
-            -Dquarkus.smallrye-graphql.log-payload=off \
-            compile test > unit-test.log 2>&1
-    - name: Dump unit test logs
-      if: always()
-      run: tail -500l unit-test.log
-    - name: Upload unit test logs
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: always()
-      with:
-        name: cryostat-storage-unittest.log
-        path: unit-test.log
-    - name: Run integration tests
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-      env:
-        CRYOSTAT_STORAGE_VERSION: pr-ci
-      with:
-        attempt_limit: 3
-        command: |
-          ./mvnw -B -U \
-            -Dquarkus.hibernate-orm.log.sql=false \
-            -Dquarkus.log.level=error \
-            -Dquarkus.http.access-log.enabled=false \
-            -Dquarkus.smallrye-graphql.log-payload=off \
-            -Dskip.surefire.tests \
-            verify > integration-test.log 2>&1
-    - name: Dump integration test logs
-      if: always()
-      run: tail -500l integration-test.log
-    - name: Upload integration test logs
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: always()
-      with:
-        name: cryostat-storage-itest.log
-        path: integration-test.log
+
+  test:
+    needs: pr_build
+    uses: ./.github/workflows/test-cryostat.yml
+    with:
+      java-version: '25'
+      storage-image-tag: pr-ci
+      run-unit-tests: true
+      run-integration-tests: true

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -39,3 +39,4 @@ jobs:
     uses: ./.github/workflows/test-cryostat.yml
     with:
       storage-image: quay.io/cryostat/cryostat-storage:pr-ci
+      attempt-limit: 1

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -33,6 +33,12 @@ jobs:
         tags: pr-ci
         containerfiles: |
           ./Dockerfile
+    - name: Save container image
+      run: podman save -o cryostat-storage.tar --format oci-archive ${{ env.CI_IMG }}:pr-ci
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: cryostat-storage
+        path: cryostat-storage.tar
 
   test:
     needs: pr_build

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -40,5 +40,3 @@ jobs:
     with:
       java-version: '25'
       storage-image-tag: pr-ci
-      run-unit-tests: true
-      run-integration-tests: true

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -38,4 +38,4 @@ jobs:
     needs: pr_build
     uses: ./.github/workflows/test-cryostat.yml
     with:
-      storage-image-tag: pr-ci
+      storage-image: quay.io/cryostat/cryostat-storage:pr-ci

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -38,5 +38,4 @@ jobs:
     needs: pr_build
     uses: ./.github/workflows/test-cryostat.yml
     with:
-      java-version: '25'
       storage-image-tag: pr-ci

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -3,9 +3,6 @@ name: Test cryostat
 on:
   workflow_call:
     inputs:
-      java-version:
-        required: true
-        type: string
       storage-image-tag:
         required: true
         type: string
@@ -17,7 +14,7 @@ jobs:
     steps:
     - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
-        java-version: ${{ inputs.java-version }}
+        java-version: '25'
         distribution: 'temurin'
         cache: 'maven'
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -11,11 +11,6 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
-      with:
-        java-version: '25'
-        distribution: 'temurin'
-        cache: 'maven'
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: ${{ github.repository_owner }}/cryostat
@@ -36,6 +31,11 @@ jobs:
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Run unit tests
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:
@@ -62,11 +62,6 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
-      with:
-        java-version: '25'
-        distribution: 'temurin'
-        cache: 'maven'
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: ${{ github.repository_owner }}/cryostat
@@ -102,6 +97,11 @@ jobs:
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Run integration tests
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -6,10 +6,67 @@ on:
       storage-image:
         required: true
         type: string
+
 jobs:
-  test-cryostat:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        repository: ${{ github.repository_owner }}/cryostat
+        ref: main
+        submodules: false
+        fetch-depth: 0
+    - name: Install podman-docker
+      run: sudo apt -y update && sudo apt -y install "podman-docker"
+    - name: Configure Podman service timeout
+      uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
+      with:
+        path: /home/runner/.config/containers/containers.conf.d/999-service-timeout.conf
+        write-mode: overwrite
+        contents: |
+          [engine]
+          service_timeout=0
+    - name: Start Podman API
+      run: systemctl --user enable --now podman.socket
+    - name: Set DOCKER_HOST environment variable
+      run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+    - name: Run unit tests
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      env:
+        CRYOSTAT_STORAGE_IMAGE: ${{ inputs.storage-image }}
+      with:
+        attempt_limit: 3
+        command: |
+          ./mvnw -B -U \
+            -Dquarkus.hibernate-orm.log.sql=false \
+            -Dquarkus.log.level=error \
+            -Dquarkus.http.access-log.enabled=false \
+            -Dquarkus.smallrye-graphql.log-payload=off \
+            compile test > unit-test.log 2>&1
+    - name: Dump unit test logs
+      if: always()
+      run: tail -500l unit-test.log
+    - name: Upload unit test logs
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
+      with:
+        name: cryostat-storage-unittest.log
+        path: unit-test.log
+
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: ${{ github.repository_owner }}/cryostat
@@ -45,33 +102,6 @@ jobs:
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
-    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
-      with:
-        java-version: '25'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Run unit tests
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-      env:
-        CRYOSTAT_STORAGE_IMAGE: ${{ inputs.storage-image }}
-      with:
-        attempt_limit: 3
-        command: |
-          ./mvnw -B -U \
-            -Dquarkus.hibernate-orm.log.sql=false \
-            -Dquarkus.log.level=error \
-            -Dquarkus.http.access-log.enabled=false \
-            -Dquarkus.smallrye-graphql.log-payload=off \
-            compile test > unit-test.log 2>&1
-    - name: Dump unit test logs
-      if: always()
-      run: tail -500l unit-test.log
-    - name: Upload unit test logs
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: always()
-      with:
-        name: cryostat-storage-unittest.log
-        path: unit-test.log
     - name: Run integration tests
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -9,15 +9,6 @@ on:
       storage-image-tag:
         required: true
         type: string
-      run-unit-tests:
-        required: false
-        type: boolean
-        default: true
-      run-integration-tests:
-        required: false
-        type: boolean
-        default: true
-
 jobs:
   test-cryostat:
     runs-on: ubuntu-latest
@@ -65,7 +56,6 @@ jobs:
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
     - name: Run unit tests
-      if: ${{ inputs.run-unit-tests }}
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:
         CRYOSTAT_STORAGE_VERSION: ${{ inputs.storage-image-tag }}
@@ -79,16 +69,15 @@ jobs:
             -Dquarkus.smallrye-graphql.log-payload=off \
             compile test > unit-test.log 2>&1
     - name: Dump unit test logs
-      if: ${{ inputs.run-unit-tests && always() }}
+      if: always()
       run: tail -500l unit-test.log
     - name: Upload unit test logs
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: ${{ inputs.run-unit-tests && always() }}
+      if: always()
       with:
         name: cryostat-storage-unittest.log
         path: unit-test.log
     - name: Run integration tests
-      if: ${{ inputs.run-integration-tests }}
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:
         CRYOSTAT_STORAGE_VERSION: ${{ inputs.storage-image-tag }}
@@ -103,11 +92,11 @@ jobs:
             -Dskip.surefire.tests \
             verify > integration-test.log 2>&1
     - name: Dump integration test logs
-      if: ${{ inputs.run-integration-tests && always() }}
+      if: always()
       run: tail -500l integration-test.log
     - name: Upload integration test logs
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: ${{ inputs.run-integration-tests && always() }}
+      if: always()
       with:
         name: cryostat-storage-itest.log
         path: integration-test.log

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -35,6 +35,12 @@ jobs:
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+    - name: Download storage image artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: cryostat-storage
+    - name: Load storage image
+      run: podman load -i cryostat-storage.tar
     - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         java-version: '25'
@@ -101,6 +107,12 @@ jobs:
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+    - name: Download storage image artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: cryostat-storage
+    - name: Load storage image
+      run: podman load -i cryostat-storage.tar
     - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         java-version: '25'

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -6,6 +6,10 @@ on:
       storage-image:
         required: true
         type: string
+      attempt-limit:
+        required: false
+        type: number
+        default: 3
 
 jobs:
   unit-test:
@@ -41,7 +45,7 @@ jobs:
       env:
         CRYOSTAT_STORAGE_IMAGE: ${{ inputs.storage-image }}
       with:
-        attempt_limit: 3
+        attempt_limit: ${{ inputs.attempt-limit }}
         command: |
           ./mvnw -B -U \
             -Dquarkus.hibernate-orm.log.sql=false \
@@ -107,7 +111,7 @@ jobs:
       env:
         CRYOSTAT_STORAGE_IMAGE: ${{ inputs.storage-image }}
       with:
-        attempt_limit: 3
+        attempt_limit: ${{ inputs.attempt-limit }}
         command: |
           ./mvnw -B -U \
             -Dquarkus.hibernate-orm.log.sql=false \

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -1,0 +1,131 @@
+name: Test cryostat
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        required: true
+        type: string
+      storage-image-tag:
+        required: true
+        type: string
+      run-unit-tests:
+        required: false
+        type: boolean
+        default: false
+      run-integration-tests:
+        required: false
+        type: boolean
+        default: false
+      run-full-verify:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  test-cryostat:
+    runs-on: ubuntu-latest
+    env:
+      CI_IMG: quay.io/cryostat/cryostat-storage
+    steps:
+    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: 'temurin'
+        cache: 'maven'
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        repository: ${{ github.repository_owner }}/cryostat
+        ref: main
+        submodules: true
+        fetch-depth: 0
+    - run: git submodule init && git submodule update
+    - name: Cache yarn packages
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: "./src/main/webui/.yarn/cache"
+        key: ${{ runner.os }}-build-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-yarn-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Initialize web assets
+      run: |
+        cd src/main/webui
+        yarn install && yarn yarn:frzinstall
+        cd -
+    - name: Install podman-docker
+      run: sudo apt -y update && sudo apt -y install "podman-docker"
+    - name: Configure Podman service timeout
+      uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
+      with:
+        path: /home/runner/.config/containers/containers.conf.d/999-service-timeout.conf
+        write-mode: overwrite
+        contents: |
+          [engine]
+          service_timeout=0
+    - name: Start Podman API
+      run: systemctl --user enable --now podman.socket
+    - name: Set DOCKER_HOST environment variable
+      run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+    - name: Run unit tests
+      if: ${{ inputs.run-unit-tests }}
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      env:
+        CRYOSTAT_STORAGE_VERSION: ${{ inputs.storage-image-tag }}
+      with:
+        attempt_limit: 3
+        command: |
+          ./mvnw -B -U \
+            -Dquarkus.hibernate-orm.log.sql=false \
+            -Dquarkus.log.level=error \
+            -Dquarkus.http.access-log.enabled=false \
+            -Dquarkus.smallrye-graphql.log-payload=off \
+            compile test > unit-test.log 2>&1
+    - name: Dump unit test logs
+      if: ${{ inputs.run-unit-tests && always() }}
+      run: tail -500l unit-test.log
+    - name: Upload unit test logs
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: ${{ inputs.run-unit-tests && always() }}
+      with:
+        name: cryostat-storage-unittest.log
+        path: unit-test.log
+    - name: Run integration tests
+      if: ${{ inputs.run-integration-tests }}
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      env:
+        CRYOSTAT_STORAGE_VERSION: ${{ inputs.storage-image-tag }}
+      with:
+        attempt_limit: 3
+        command: |
+          ./mvnw -B -U \
+            -Dquarkus.hibernate-orm.log.sql=false \
+            -Dquarkus.log.level=error \
+            -Dquarkus.http.access-log.enabled=false \
+            -Dquarkus.smallrye-graphql.log-payload=off \
+            -Dskip.surefire.tests \
+            verify > integration-test.log 2>&1
+    - name: Dump integration test logs
+      if: ${{ inputs.run-integration-tests && always() }}
+      run: tail -500l integration-test.log
+    - name: Upload integration test logs
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: ${{ inputs.run-integration-tests && always() }}
+      with:
+        name: cryostat-storage-itest.log
+        path: integration-test.log
+    - name: Build cryostat
+      if: ${{ inputs.run-full-verify }}
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      env:
+        CRYOSTAT_STORAGE_VERSION: ${{ inputs.storage-image-tag }}
+      with:
+        attempt_limit: 3
+        command: |
+          ./mvnw -B \
+            -Dquarkus.hibernate-orm.log.sql=false \
+            -Dquarkus.log.level=error \
+            -Dquarkus.http.access-log.enabled=false \
+            -Dquarkus.smallrye-graphql.log-payload=off \
+            clean verify

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -12,15 +12,11 @@ on:
       run-unit-tests:
         required: false
         type: boolean
-        default: false
+        default: true
       run-integration-tests:
         required: false
         type: boolean
-        default: false
-      run-full-verify:
-        required: false
-        type: boolean
-        default: false
+        default: true
 
 jobs:
   test-cryostat:
@@ -115,17 +111,3 @@ jobs:
       with:
         name: cryostat-storage-itest.log
         path: integration-test.log
-    - name: Build cryostat
-      if: ${{ inputs.run-full-verify }}
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-      env:
-        CRYOSTAT_STORAGE_VERSION: ${{ inputs.storage-image-tag }}
-      with:
-        attempt_limit: 3
-        command: |
-          ./mvnw -B \
-            -Dquarkus.hibernate-orm.log.sql=false \
-            -Dquarkus.log.level=error \
-            -Dquarkus.http.access-log.enabled=false \
-            -Dquarkus.smallrye-graphql.log-payload=off \
-            clean verify

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -3,14 +3,12 @@ name: Test cryostat
 on:
   workflow_call:
     inputs:
-      storage-image-tag:
+      storage-image:
         required: true
         type: string
 jobs:
   test-cryostat:
     runs-on: ubuntu-latest
-    env:
-      CI_IMG: quay.io/cryostat/cryostat-storage
     steps:
     - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
@@ -55,7 +53,7 @@ jobs:
     - name: Run unit tests
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:
-        CRYOSTAT_STORAGE_VERSION: ${{ inputs.storage-image-tag }}
+        CRYOSTAT_STORAGE_IMAGE: ${{ inputs.storage-image }}
       with:
         attempt_limit: 3
         command: |
@@ -77,7 +75,7 @@ jobs:
     - name: Run integration tests
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:
-        CRYOSTAT_STORAGE_VERSION: ${{ inputs.storage-image-tag }}
+        CRYOSTAT_STORAGE_IMAGE: ${{ inputs.storage-image }}
       with:
         attempt_limit: 3
         command: |

--- a/.github/workflows/test-cryostat.yml
+++ b/.github/workflows/test-cryostat.yml
@@ -10,11 +10,6 @@ jobs:
   test-cryostat:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
-      with:
-        java-version: '25'
-        distribution: 'temurin'
-        cache: 'maven'
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: ${{ github.repository_owner }}/cryostat
@@ -50,6 +45,11 @@ jobs:
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+    - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Run unit tests
       uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       env:


### PR DESCRIPTION
# Welcome to Cryostat3! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See cryostatio/cryostat#1590

## Description of the change:
1. Refactors `pr-ci` and `nightly` to extract a common reusable workflow file so there is less duplication
2. Adds the Podman `service_timeout` configuration to work around the `Broken pipe` testcontainers issue often observed in CI
